### PR TITLE
fix bug of Repetition Hallucunation using Top-k Tree Decoding(#29)

### DIFF
--- a/whisper_medusa/models/medusa_utils.py
+++ b/whisper_medusa/models/medusa_utils.py
@@ -635,7 +635,7 @@ def update_inference_inputs(
     # Append the tokens from the best candidate to the input sequence
     next_tokens = candidates[None, best_candidate, : accept_length + 1]
     if use_base_logits:
-        additional_next_token = torch.argmax(logits[:, 0], dim=-1)
+        additional_next_token = torch.argmax(logits[None, best_candidate, 0], dim=-1)
         next_tokens = torch.cat(
             [next_tokens, additional_next_token.unsqueeze(0)], dim=-1
         )


### PR DESCRIPTION
Address the issue of repetition hallucination by utilizing Top-k Tree Decoding (#29). In tree decoding mode, where multiple logits are produced, ensure that the best candidate logits are accurately selected.